### PR TITLE
33 enhanced filtration

### DIFF
--- a/frontend/src/UserContext.js
+++ b/frontend/src/UserContext.js
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const UserContext = createContext(false);

--- a/frontend/src/app/App.js
+++ b/frontend/src/app/App.js
@@ -1,19 +1,30 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './App.css';
 import Home from '../pages/Home';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import Restaurants from '../pages/Restaurants';
 import ScrollToTop from '../components/ScrollToTop';
 import Footer from '../components/footer/Footer';
+import { UserContext } from '../UserContext';
 
 function App() {
+  const [pragueCollegePath, setPragueCollegePath] = useState(false);
+  const [clickedDistrict, setClickedDistrict] = useState(false);
+  const [clickedSuggestion, setClickedSuggestion] = useState(false);
+
   return (
     <>
       <Router>
         <ScrollToTop />
         <Switch>
-          <Route path='/' exact component={Home} />
-          <Route path='/restaurants' component={Restaurants} />
+          <UserContext.Provider value={{
+            pragueCollegePath, setPragueCollegePath,
+            clickedDistrict, setClickedDistrict,
+            clickedSuggestion, setClickedSuggestion
+          }}>
+            <Route path='/' exact component={Home} />
+            <Route path='/restaurants' component={Restaurants} />
+          </UserContext.Provider>
         </Switch>
         <Footer />
       </Router>

--- a/frontend/src/app/App.js
+++ b/frontend/src/app/App.js
@@ -11,7 +11,7 @@ function App() {
   const [pragueCollegePath, setPragueCollegePath] = useState(false);
   const [clickedDistrict, setClickedDistrict] = useState(false);
   const [clickedSuggestion, setClickedSuggestion] = useState(false);
-  const [checkedDistance, setCheckedDistance ] = useState("1000")
+  const [checkedDistance, setCheckedDistance] = useState("1000")
 
   return (
     <>

--- a/frontend/src/app/App.js
+++ b/frontend/src/app/App.js
@@ -11,6 +11,7 @@ function App() {
   const [pragueCollegePath, setPragueCollegePath] = useState(false);
   const [clickedDistrict, setClickedDistrict] = useState(false);
   const [clickedSuggestion, setClickedSuggestion] = useState(false);
+  const [checkedDistance, setCheckedDistance ] = useState("1000")
 
   return (
     <>
@@ -20,7 +21,8 @@ function App() {
           <UserContext.Provider value={{
             pragueCollegePath, setPragueCollegePath,
             clickedDistrict, setClickedDistrict,
-            clickedSuggestion, setClickedSuggestion
+            clickedSuggestion, setClickedSuggestion,
+            checkedDistance,setCheckedDistance
           }}>
             <Route path='/' exact component={Home} />
             <Route path='/restaurants' component={Restaurants} />

--- a/frontend/src/components/button/Button.js
+++ b/frontend/src/components/button/Button.js
@@ -13,9 +13,10 @@ export const Button = ({
   buttonSize,
 }) => {
 
-  const checkButtonStyle = STYLES.includes(buttonStyle)
-    ? buttonStyle
-    : STYLES[0];
+  const checkButtonStyle = STYLES.includes(buttonStyle) ?
+    buttonStyle
+    :
+    STYLES[0];
 
   const checkButtonSize = SIZES.includes(buttonSize) ? buttonSize : SIZES[0];
 

--- a/frontend/src/components/cards/CardItem.js
+++ b/frontend/src/components/cards/CardItem.js
@@ -1,19 +1,21 @@
 import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
-import './Cards.css';
 import { UserContext } from '../../UserContext';
+import './Cards.css';
 
 function CardItem(props) {
   const { setClickedSuggestion } = useContext(UserContext)
-  
+
   return (
     <>
-      <li className='cards__item'
+      <li
+        className='cards__item'
         onClick={() => setClickedSuggestion(props.filterValue)}
       >
           <Link className='cards__item__link' to="/restaurants">
-            <figure className='cards__item__pic-wrap'
-                    data-category={props.label}>
+          <figure
+            className='cards__item__pic-wrap'
+            data-category={props.label}>
               <img
                 className='cards__item__img'
                 alt='Food Category'

--- a/frontend/src/components/cards/CardItem.js
+++ b/frontend/src/components/cards/CardItem.js
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import './Cards.css';
+import { UserContext } from '../../UserContext';
 
 function CardItem(props) {
+  const { setClickedSuggestion } = useContext(UserContext)
+  
   return (
     <>
-        <li className='cards__item'>
+      <li className='cards__item'
+        onClick={() => setClickedSuggestion(props.filterValue)}
+      >
           <Link className='cards__item__link' to="/restaurants">
             <figure className='cards__item__pic-wrap'
                     data-category={props.label}>

--- a/frontend/src/components/cards/Cards.js
+++ b/frontend/src/components/cards/Cards.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import './Cards.css';
 import CardItem from './CardItem';
 import { TopSuggestionsData } from './TopSuggestionsData'
+import './Cards.css';
 
 function Cards() {
-
   return (
     <div className='cards'>
       <h1>Check Out the Top Suggestions! </h1>
@@ -13,23 +12,23 @@ function Cards() {
           <ul className='cards__items'>
             {TopSuggestionsData.map(suggestion => {
               return TopSuggestionsData.indexOf(suggestion) < 2 &&
-              <CardItem
-              src={suggestion.src}
-              text={suggestion.text}
-              label={suggestion.label}
-              filterValue={suggestion.filterValue}
-            />
+                      <CardItem
+                        src={suggestion.src}
+                        text={suggestion.text}
+                        label={suggestion.label}
+                        filterValue={suggestion.filterValue}
+                      />
             })}
           </ul>
           <ul className='cards__items'>
             {TopSuggestionsData.map(suggestion => {
               return TopSuggestionsData.indexOf(suggestion) >= 2 &&
-              <CardItem
-              src={suggestion.src}
-              text={suggestion.text}
-              label={suggestion.label}
-              filterValue={suggestion.filterValue}
-            />
+                      <CardItem
+                        src={suggestion.src}
+                        text={suggestion.text}
+                        label={suggestion.label}
+                        filterValue={suggestion.filterValue}
+                      />
             })}
           </ul>
         </div>

--- a/frontend/src/components/cards/Cards.js
+++ b/frontend/src/components/cards/Cards.js
@@ -1,41 +1,36 @@
 import React from 'react';
 import './Cards.css';
 import CardItem from './CardItem';
+import { TopSuggestionsData } from './TopSuggestionsData'
 
 function Cards() {
+
   return (
     <div className='cards'>
       <h1>Check Out the Top Suggestions! </h1>
       <div className='cards__container'>
         <div className='cards__wrapper'>
           <ul className='cards__items'>
-            <CardItem
-              src='images/Home/international.webp'
-              text="View the city's more than 1000 International restaurants"
-              label='International'
+            {TopSuggestionsData.map(suggestion => {
+              return TopSuggestionsData.indexOf(suggestion) < 2 &&
+              <CardItem
+              src={suggestion.src}
+              text={suggestion.text}
+              label={suggestion.label}
+              filterValue={suggestion.filterValue}
             />
-            <CardItem
-              src='images/Home/italian.jpg'
-              text="Explore all the Italian restaurants of Prague"
-              label='Italian'
-            />
+            })}
           </ul>
           <ul className='cards__items'>
-            <CardItem
-              src='images/Home/czech.jpg'
-              text='Find your most suitable Czech restaurant'
-              label='Czech'
+            {TopSuggestionsData.map(suggestion => {
+              return TopSuggestionsData.indexOf(suggestion) >= 2 &&
+              <CardItem
+              src={suggestion.src}
+              text={suggestion.text}
+              label={suggestion.label}
+              filterValue={suggestion.filterValue}
             />
-            <CardItem
-              src='images/Home/glutenfree.webp'
-              text='Check out  the restaurants with gluten free options'
-              label='Gluten Free'
-            />
-            <CardItem
-              src='images/Home/vegan.jpeg'
-              text='Check out the restaurants with vegan and vegetarian meals'
-              label='Vegan/Vegetarian'
-            />
+            })}
           </ul>
         </div>
       </div>

--- a/frontend/src/components/cards/TopSuggestionsData.js
+++ b/frontend/src/components/cards/TopSuggestionsData.js
@@ -1,0 +1,32 @@
+export const TopSuggestionsData = [
+    {
+      src: 'images/Home/international.webp',
+      text: "View the city's more than 1000 International restaurants",
+      label: 'International',
+      filterValue: 'international'
+    },
+     {
+      src: 'images/Home/italian.jpg',
+      text: "Explore all the Italian restaurants of Prague",
+      label: 'Italian',
+      filterValue: 'italian'
+    },
+     {
+      src: 'images/Home/czech.jpg',
+      text: "Find your most suitable Czech restaurant",
+      label: 'Czech',
+      filterValue: 'czech'
+    },
+     {
+      src: 'images/Home/glutenfree.webp',
+      text: "Check out  the restaurants with gluten free options",
+      label: 'Gluten Free',
+      filterValue: 'gluten-free'
+    },
+     {
+      src: 'images/Home/vegan.jpeg',
+      text: "Check out the restaurants with vegetarian meals",
+      label: 'Vegetarian',
+      filterValue: 'vegetarian'
+    }
+  ]

--- a/frontend/src/components/cards/TopSuggestionsData.js
+++ b/frontend/src/components/cards/TopSuggestionsData.js
@@ -1,32 +1,32 @@
 export const TopSuggestionsData = [
-    {
-      src: 'images/Home/international.webp',
-      text: "View the city's more than 1000 International restaurants",
-      label: 'International',
-      filterValue: 'international'
-    },
-     {
-      src: 'images/Home/italian.jpg',
-      text: "Explore all the Italian restaurants of Prague",
-      label: 'Italian',
-      filterValue: 'italian'
-    },
-     {
-      src: 'images/Home/czech.jpg',
-      text: "Find your most suitable Czech restaurant",
-      label: 'Czech',
-      filterValue: 'czech'
-    },
-     {
-      src: 'images/Home/glutenfree.webp',
-      text: "Check out  the restaurants with gluten free options",
-      label: 'Gluten Free',
-      filterValue: 'gluten-free'
-    },
-     {
-      src: 'images/Home/vegan.jpeg',
-      text: "Check out the restaurants with vegetarian meals",
-      label: 'Vegetarian',
-      filterValue: 'vegetarian'
-    }
-  ]
+  {
+    src: 'images/Home/international.webp',
+    text: "View the city's more than 1000 International restaurants",
+    label: 'International',
+    filterValue: 'international'
+  },
+  {
+    src: 'images/Home/italian.jpg',
+    text: "Explore all the Italian restaurants of Prague",
+    label: 'Italian',
+    filterValue: 'italian'
+  },
+  {
+    src: 'images/Home/czech.jpg',
+    text: "Find your most suitable Czech restaurant",
+    label: 'Czech',
+    filterValue: 'czech'
+  },
+  {
+    src: 'images/Home/glutenfree.webp',
+    text: "Check out  the restaurants with gluten free options",
+    label: 'Gluten Free',
+    filterValue: 'gluten-free'
+  },
+  {
+    src: 'images/Home/vegan.jpeg',
+    text: "Check out the restaurants with vegetarian meals",
+    label: 'Vegetarian',
+    filterValue: 'vegetarian'
+  }
+]

--- a/frontend/src/components/college/CollegeSection.css
+++ b/frontend/src/components/college/CollegeSection.css
@@ -2,9 +2,8 @@
   color: black;
   background-color: #fff;
   padding: 5rem;
-
-
 }
+
 .container {
   display: flex;
   flex-flow: column;
@@ -70,7 +69,7 @@
 }
 
 .dark {
- color: rgb(255, 174, 0);
+  color: rgb(255, 174, 0);
 }
 
 .description {
@@ -82,7 +81,7 @@
 
 .img-wrapper {
   max-width: 545px;
-   padding-top: 0;
+  padding-top: 0;
   margin-left: 2rem;
 }
 
@@ -103,13 +102,14 @@
 
 @media screen and (max-width: 1024px) {
   .container {
-   display: flex;
+    display: flex;
     flex-flow: column;
     align-items: center;
     max-width: 1120px;
     width: 90%;
     margin: 0 auto;
   }
+
   .text-wrapper .btn {
     width: inherit;
   }
@@ -119,13 +119,14 @@
     text-align: center;
     max-width: none;
   }
+
   .row {
     align-items: center;
     justify-content: center;
     text-align: center;
   }
-  .text-wrapper {
 
+  .text-wrapper {
     margin-right: 0;
     text-align: center;
     justify-content: center;
@@ -135,6 +136,6 @@
     max-width: 100%;
     flex-basis: 100%;
     justify-content: center;
-  align-items: center;
+    align-items: center;
   }
 }

--- a/frontend/src/components/college/CollegeSection.js
+++ b/frontend/src/components/college/CollegeSection.js
@@ -1,15 +1,15 @@
 import React, { useContext, useEffect, useState } from 'react';
-import './CollegeSection.css';
 import { Link } from 'react-router-dom';
 import { Button } from '../button/Button';
 import Aos from 'aos';
 import 'aos/dist/aos.css';
 import { UserContext } from '../../UserContext';
+import './CollegeSection.css';
 
 function CollegeSection() {
   const { setPragueCollegePath } = useContext(UserContext)
-  const [button, setImage] = useState(true);
-  
+  const [image, setImage] = useState(true);
+
   const showImage = () => {
     if (window.innerWidth <= 1024) {
       setImage(false);
@@ -22,11 +22,12 @@ function CollegeSection() {
    showImage();
   }, []);
 
- useEffect(() => {
-  Aos.init({ duration: 1000 })
+  useEffect(() => {
+    Aos.init({ duration: 1000 })
   }, [])
 
   window.addEventListener('resize', showImage);
+
   return (
     <>
       <div className= 'college-section'>
@@ -42,9 +43,11 @@ function CollegeSection() {
               <div className='text-wrapper'>
                 <div className='top-line'>
                   For Prague College Students
-                  <img src='images/Home/PC.png'
-                       className="prague-college-logo"
-                       alt="pc logo" />
+                  <img
+                    src='images/Home/PC.png'
+                    className="prague-college-logo"
+                    alt="pc logo"
+                  />
                 </div>
                 <h1 className= 'heading'>
                   Find the best food places near the Prague College
@@ -55,22 +58,27 @@ function CollegeSection() {
                   and find a suitable restaurant based on your own preferences.
                 </p>
                 <Link to='/restaurants' onClick={() => setPragueCollegePath(true)}>
-                  <Button buttonSize='btn--large'
-                          buttonStyle='btn--search'
-                          className="btn-see-more"
+                  <Button
+                    buttonSize='btn--large'
+                    buttonStyle='btn--search'
+                    className="btn-see-more"
                   >
                     Get Started
                   </Button>
                 </Link>
               </div>
-            </div>{button &&
+            </div>
+            {image &&
               <div className='col'>
                 <div className='img-wrapper'>
-                  <img src='images/Home/lnch.jpg'
-                       alt='Student'
-                       className='student-img' />
+                  <img
+                    src='images/Home/lnch.jpg'
+                    alt='Student'
+                    className='student-img'
+                  />
                 </div>
-            </div>}
+              </div>
+            }
           </div>
         </div>
       </div>

--- a/frontend/src/components/college/CollegeSection.js
+++ b/frontend/src/components/college/CollegeSection.js
@@ -1,25 +1,30 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import './CollegeSection.css';
 import { Link } from 'react-router-dom';
 import { Button } from '../button/Button';
 import Aos from 'aos';
 import 'aos/dist/aos.css';
+import { UserContext } from '../../UserContext';
 
-function CollegeSection () {
-    useEffect(() => {
-    Aos.init({ duration: 1000 })
-    }, [])
-     const [button, setImage] = useState(true);
-   const showImage = () => {
+function CollegeSection() {
+  const { setPragueCollegePath } = useContext(UserContext)
+  const [button, setImage] = useState(true);
+  
+  const showImage = () => {
     if (window.innerWidth <= 1024) {
       setImage(false);
     } else {
       setImage(true);
     }
   };
-    useEffect(() => {
+
+  useEffect(() => {
    showImage();
   }, []);
+
+ useEffect(() => {
+  Aos.init({ duration: 1000 })
+  }, [])
 
   window.addEventListener('resize', showImage);
   return (
@@ -49,7 +54,7 @@ function CollegeSection () {
                   for their lunch-breaks as soon as possible. Click on Get Started
                   and find a suitable restaurant based on your own preferences.
                 </p>
-                <Link to='/restaurants'>
+                <Link to='/restaurants' onClick={() => setPragueCollegePath(true)}>
                   <Button buttonSize='btn--large'
                           buttonStyle='btn--search'
                           className="btn-see-more"

--- a/frontend/src/components/districts/District_item.js
+++ b/frontend/src/components/districts/District_item.js
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import './Districts.css';
+import { UserContext } from '../../UserContext';
 
 function DistrictItem(props) {
+  const { setClickedDistrict } = useContext(UserContext)
+
   return (
     <>
-        <li className='districts__item'>
+      <li className='districts__item'
+        onClick={() => setClickedDistrict(props.district)}
+      >
           <Link className='districts__item__link' to='/restaurants'>
             <h4>
               {props.district} ({props.num_of_restaurants} places)

--- a/frontend/src/components/districts/District_item.js
+++ b/frontend/src/components/districts/District_item.js
@@ -1,23 +1,24 @@
 import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
-import './Districts.css';
 import { UserContext } from '../../UserContext';
+import './Districts.css';
 
 function DistrictItem(props) {
   const { setClickedDistrict } = useContext(UserContext)
 
   return (
     <>
-      <li className='districts__item'
+      <li
+        className='districts__item'
         onClick={() => setClickedDistrict(props.district)}
       >
-          <Link className='districts__item__link' to='/restaurants'>
-            <h4>
-              {props.district} ({props.num_of_restaurants} places)
-            </h4>
-            <i class="fas fa-angle-right" />
-          </Link>
-        </li>
+        <Link className='districts__item__link' to='/restaurants'>
+          <h4>
+            {props.district} ({props.num_of_restaurants} places)
+          </h4>
+          <i class="fas fa-angle-right" />
+        </Link>
+      </li>
     </>
   );
 }

--- a/frontend/src/components/districts/Districts.css
+++ b/frontend/src/components/districts/Districts.css
@@ -1,55 +1,55 @@
 .districts {
-    padding: 3.5rem 4rem;
-    background: #fff;
+  padding: 3.5rem 4rem;
+  background: #fff;
 }
 
 .districts__container {
-    display: flex;
-    flex-flow: column;
-    align-items: center;
-    max-width: 1120px;
-    width: 90%;
-    margin: 0 auto;
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  max-width: 1120px;
+  width: 90%;
+  margin: 0 auto;
 }
 
 .districts__wrapper {
-    position: relative;
-    margin: 50px 0 0px;
-    width: 100%;
+  position: relative;
+  margin: 50px 0 0px;
+  width: 100%;
 }
 
 .districts__items {
-    display: flex;
-    flex-direction: row;
-    margin-bottom: 30px;
-    width:100%
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 30px;
+  width:100%
 }
 
 .districts__item {
-    position: relative;
-    display: flex;
-    flex: 1;
-    margin: 0 1rem;
-    border-radius: 8px;
+  position: relative;
+  display: flex;
+  flex: 1;
+  margin: 0 1rem;
+  border-radius: 8px;
 }
 
 .districts__item__link {
-    display: flex;
-    flex-direction: row;
-    width: 100%;
-    height: 50px;
-    color: #252e48;
-    box-shadow: 0 6px 20px rgba(2, 29, 36, 0.801);
-    border-radius: 10px;
-    text-decoration: none;
-    align-items: center;
-    text-align: center;
-    justify-content: center;
-    background-color: rgb(248, 246, 246);
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 50px;
+  color: #252e48;
+  box-shadow: 0 6px 20px rgba(2, 29, 36, 0.801);
+  border-radius: 10px;
+  text-decoration: none;
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+  background-color: rgb(248, 246, 246);
 }
 
 .districts__item__link:hover {
-    box-shadow: 0 6px 20px rgba(65, 6, 6, 0.801);
+  box-shadow: 0 6px 20px rgba(65, 6, 6, 0.801);
 }
 
 h4 {
@@ -91,7 +91,7 @@ h4 {
       padding: 5% 5% 5% 0;
     }
 
-    .districts__wrapper {
+   .districts__wrapper {
       width: 420px;
     }
 
@@ -111,11 +111,11 @@ h4 {
       width: 90%;
     }
 
-   h4 {
+    h4 {
       padding: 5% 14% 5% 3%;
     }
 
-   .fa-angle-right {
+    .fa-angle-right {
       padding: 5% 3% 5% 0;
     }
 }

--- a/frontend/src/components/districts/Districts.js
+++ b/frontend/src/components/districts/Districts.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import DistrictItem from './District_item';
 import './Districts.css';
+import { PopularDistrictsData }  from './PopularDistrictsData'
 
 function Districts() {
   return (
@@ -9,32 +10,22 @@ function Districts() {
       <div className="districts__container">
         <div className="districts__wrapper">
           <ul className="districts__items">
-            <DistrictItem
-              district="Prague 1"
-              num_of_restaurants="50"
-            />
-            <DistrictItem
-              district="Prague 2"
-              num_of_restaurants="50"
-            />
-            <DistrictItem
-              district="Prague 3"
-              num_of_restaurants="50"
-            />
-        </ul>
-        <ul className="districts__items">
-            <DistrictItem
-              district="Prague 4"
-              num_of_restaurants="50"
-            />
-            <DistrictItem
-              district="Prague 5"
-              num_of_restaurants="50"
-            />
-            <DistrictItem
-              district="Prague 6"
-              num_of_restaurants="50"
-            />
+            {PopularDistrictsData.map(district =>
+            { return PopularDistrictsData.indexOf(district) < 3 &&
+                   <DistrictItem
+                    district= {district.district}
+                    num_of_restaurants={district.num_of_restaurants}
+                  />
+            })}
+          </ul>
+          <ul className="districts__items">
+            {PopularDistrictsData.map(district =>
+            { return PopularDistrictsData.indexOf(district) >= 3 &&
+                   <DistrictItem
+                    district= {district.district}
+                    num_of_restaurants={district.num_of_restaurants}
+                  />
+            })}
           </ul>
           </div>
         </div>

--- a/frontend/src/components/districts/Districts.js
+++ b/frontend/src/components/districts/Districts.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import DistrictItem from './District_item';
-import './Districts.css';
 import { PopularDistrictsData }  from './PopularDistrictsData'
+import './Districts.css';
 
 function Districts() {
   return (
@@ -10,21 +10,21 @@ function Districts() {
       <div className="districts__container">
         <div className="districts__wrapper">
           <ul className="districts__items">
-            {PopularDistrictsData.map(district =>
-            { return PopularDistrictsData.indexOf(district) < 3 &&
-                   <DistrictItem
-                    district= {district.district}
-                    num_of_restaurants={district.num_of_restaurants}
-                  />
+            {PopularDistrictsData.map(district => {
+              return PopularDistrictsData.indexOf(district) < 3 &&
+                       <DistrictItem
+                          district= {district.district}
+                          num_of_restaurants={district.num_of_restaurants}
+                      />
             })}
           </ul>
           <ul className="districts__items">
-            {PopularDistrictsData.map(district =>
-            { return PopularDistrictsData.indexOf(district) >= 3 &&
-                   <DistrictItem
-                    district= {district.district}
-                    num_of_restaurants={district.num_of_restaurants}
-                  />
+            {PopularDistrictsData.map(district => {
+              return PopularDistrictsData.indexOf(district) >= 3 &&
+                      <DistrictItem
+                        district= {district.district}
+                        num_of_restaurants={district.num_of_restaurants}
+                      />
             })}
           </ul>
           </div>

--- a/frontend/src/components/districts/PopularDistrictsData.js
+++ b/frontend/src/components/districts/PopularDistrictsData.js
@@ -1,0 +1,26 @@
+export const PopularDistrictsData = [
+    {
+      district: "Praha 1",
+      num_of_restaurants: "1062"
+    },
+    {
+      district: "Praha 2",
+      num_of_restaurants: "387"
+    },
+     {
+      district: "Praha 4",
+      num_of_restaurants: "296"
+    },
+    {
+      district: "Praha 5",
+      num_of_restaurants: "310"
+    },
+    {
+      district: "Praha 6",
+      num_of_restaurants: "222"
+    },
+    {
+      district: "Praha 10",
+      num_of_restaurants: "259"
+    }
+  ]

--- a/frontend/src/components/districts/PopularDistrictsData.js
+++ b/frontend/src/components/districts/PopularDistrictsData.js
@@ -1,26 +1,26 @@
 export const PopularDistrictsData = [
-    {
-      district: "Praha 1",
-      num_of_restaurants: "1062"
-    },
-    {
-      district: "Praha 2",
-      num_of_restaurants: "387"
-    },
-     {
-      district: "Praha 4",
-      num_of_restaurants: "296"
-    },
-    {
-      district: "Praha 5",
-      num_of_restaurants: "310"
-    },
-    {
-      district: "Praha 6",
-      num_of_restaurants: "222"
-    },
-    {
-      district: "Praha 10",
-      num_of_restaurants: "259"
-    }
-  ]
+  {
+    district: "Praha 1",
+    num_of_restaurants: "1062"
+  },
+  {
+    district: "Praha 2",
+    num_of_restaurants: "387"
+  },
+  {
+    district: "Praha 4",
+    num_of_restaurants: "296"
+  },
+  {
+    district: "Praha 5",
+    num_of_restaurants: "310"
+  },
+  {
+    district: "Praha 6",
+    num_of_restaurants: "222"
+  },
+  {
+    district: "Praha 10",
+    num_of_restaurants: "259"
+  }
+]

--- a/frontend/src/components/filtration/FiltersData.js
+++ b/frontend/src/components/filtration/FiltersData.js
@@ -1,206 +1,221 @@
-export const filters = [
-        {
-            category: "cuisine",
-            filterName: "Cuisine",
-            options: [
-                {
-                    filterValue: "american",
-                    value: "American"
-                },
-                {
-                    filterValue: "asian",
-                    value: "Asian"
-                },
-                {
-                    filterValue: "italian",
-                    value: "Italian"
-                },
-                {
-                    filterValue: "indian",
-                    value: "Indian"
-                },
-                {
-                    filterValue: "japanese",
-                    value: "Japanese"
-                },
-                {
-                    filterValue: "vietnamese",
-                    value: "Vietnamese"
-                },
-                {
-                    filterValue: "spanish",
-                    value: "Spanish"
-                },
-                {
-                    filterValue: "mediterranean",
-                    value: "Mediterranean"
-                },
-                {
-                    filterValue: "french",
-                    value: "French"
-                },
-                {
-                    filterValue: "thai",
-                    value: "Thai"
-                },
-                 {
-                    filterValue: "mexican",
-                    value: "Mexican"
-                },
-                {
-                    filterValue: "international",
-                    value: "International"
-                },
-                {
-                    filterValue: "czech",
-                    value: "Czech"
-                },
-                {
-                    filterValue: "english",
-                    value: "English"
-                },
-                {
-                    filterValue: "balkan",
-                    value: "Balkan"
-                },
-                {
-                    filterValue: "brazil",
-                    value: "Brazil"
-                },
-                {
-                    filterValue: "russian",
-                    value: "Russian"
-                },
-                {
-                    filterValue: "chinese",
-                    value: "Chinese"
-                },
-                {
-                    filterValue: "greek",
-                    value: "Greek"
-                },
-                 {
-                    filterValue: "arabic",
-                    value: "Arabic"
-                },
-                {
-                    filterValue: "korean",
-                    value: "Korean"
-                }
+export const FiltersData = [
+    {
+        category: "cuisine",
+        filterName: "Cuisine",
+        options: [
+            {
+                filterValue: "american",
+                value: "American"
+            },
+            {
+                filterValue: "asian",
+                value: "Asian"
+            },
+            {
+                filterValue: "italian",
+                value: "Italian"
+            },
+            {
+                filterValue: "indian",
+                value: "Indian"
+            },
+            {
+                filterValue: "japanese",
+                value: "Japanese"
+            },
+            {
+                filterValue: "vietnamese",
+                value: "Vietnamese"
+            },
+            {
+                filterValue: "spanish",
+                value: "Spanish"
+            },
+            {
+                filterValue: "mediterranean",
+                value: "Mediterranean"
+            },
+            {
+                filterValue: "french",
+                value: "French"
+            },
+            {
+                filterValue: "thai",
+                value: "Thai"
+            },
+            {
+                filterValue: "mexican",
+                value: "Mexican"
+            },
+            {
+                filterValue: "international",
+                value: "International"
+            },
+            {
+                filterValue: "czech",
+                value: "Czech"
+            },
+            {
+                filterValue: "english",
+                value: "English"
+            },
+            {
+                filterValue: "balkan",
+                value: "Balkan"
+            },
+            {
+                filterValue: "brazil",
+                value: "Brazil"
+            },
+            {
+                filterValue: "russian",
+                value: "Russian"
+            },
+            {
+                filterValue: "chinese",
+                value: "Chinese"
+            },
+            {
+                filterValue: "greek",
+                value: "Greek"
+            },
+            {
+                filterValue: "arabic",
+                value: "Arabic"
+            },
+            {
+                filterValue: "korean",
+                value: "Korean"
+            }
+        ]
+    },
+    {
+        category: "price-range",
+        filterName: "Price Range",
+        options: [
+            {
+                filterValue: "0-300",
+                value: "0 - 300 Kč"
+            },
+            {
+                filterValue: "300-600",
+                value: "300 - 600 Kč"
+            },
+            {
+                filterValue: "600-",
+                value: "Over 600 Kč"
+            }
+        ]
+    },
+    {
+        category: "other",
+        filterName: "Services",
+        options: [
+            {
+                filterValue: "delivery-options",
+                value: "Delivery"
+            },
+            {
+                filterValue: "takeaway",
+                value: "Takeaway"
+            }
+        ]
+    },
+    {
+        category: "district",
+        filterName: "Localities",
+        options: [
+            {
+                filterValue: "Praha 1",
+                value: "Praha 1"
+            },
+            {
+                filterValue: "Praha 2",
+                value: "Praha 2"
+            },
+            {
+                filterValue: "Praha 3",
+                value: "Praha 3"
+            },
+            {
+                filterValue: "Praha 4",
+                value: "Praha 4"
+            },
+            {
+                filterValue: "Praha 5",
+                value: "Praha 5"
+            },
+            {
+                filterValue: "Praha 6",
+                value: "Praha 6"
+            },
+            {
+                filterValue: "Praha 7",
+                value: "Praha 7"
+            },
+            {
+                filterValue: "Praha 8",
+                value: "Praha 8"
+            },
+            {
+                filterValue: "Praha 9",
+                value: "Praha 9"
+            },
+            {
+                filterValue: "Praha 10",
+                value: "Praha 10"
+            }
+        ]
+    },
+    {
+        category: "other",
+        filterName: "Suggested",
+        options: [
+            {
+                filterValue: "open now",
+                value: "Open Now"
+            },
+            {
+                filterValue: "near me",
+                value: "Near me"
+            }
+        ]
+    },
+    {
+        category: "other",
+        filterName: "Featured",
+        options: [
+            {
+                filterValue: "vegetarian",
+                value: "Vegetarian"
+            },
+            {
+                filterValue: "vegan",
+                value: "Vegan"
+            },
+            {
+                filterValue: "gluten-free",
+                value: "Gluten Free"
+            }
+        ]
+    }
+]
 
-
-
-            ]
-        },
-        {
-            category: "price-range",
-            filterName: "Price Range",
-            options: [
-                {
-                    filterValue: "0-300",
-                    value: "0 - 300 Kč"
-                },
-                {
-                    filterValue: "300-600",
-                    value: "300 - 600 Kč"
-                },
-                {
-                    filterValue: "600-",
-                    value: "Over 600 Kč"
-                }
-            ]
-        },
-        {
-            category: "other",
-            filterName: "Services",
-            options: [
-                {
-                    filterValue: "delivery-options",
-                    value: "Delivery"
-                },
-                {
-                    filterValue: "takeaway",
-                    value: "Takeaway"
-                }
-            ]
-        },
-        {
-            category: "district",
-            filterName: "Localities",
-            options: [
-                {
-                    filterValue: "Praha 1",
-                    value: "Praha 1"
-                },
-                {
-                    filterValue: "Praha 2",
-                    value: "Praha 2"
-                },
-                {
-                    filterValue: "Praha 3",
-                    value: "Praha 3"
-                },
-                                {
-                    filterValue: "Praha 4",
-                    value: "Praha 4"
-                },
-                                {
-                    filterValue: "Praha 5",
-                    value: "Praha 5"
-                },
-                {
-                    filterValue: "Praha 6",
-                    value: "Praha 6"
-                },
-                {
-                    filterValue: "Praha 7",
-                    value: "Praha 7"
-                },
-                                {
-                    filterValue: "Praha 8",
-                    value: "Praha 8"
-                },
-                                {
-                    filterValue: "Praha 9",
-                    value: "Praha 9"
-                },
-                                {
-                    filterValue: "Praha 10",
-                    value: "Praha 10"
-                }
-            ]
-        },
-        {
-             category: "other",
-            filterName: "Suggested",
-            options: [
-                {
-                    filterValue: "open now",
-                    value: "Open Now"
-                },
-                {
-                    filterValue: "near me",
-                    value: "Near me"
-                },
-            ]
-        },
-        {
-              category:"other",
-            filterName: "Featured",
-            options: [
-                {
-                    filterValue: "vegetarian",
-                    value: "Vegetarian"
-                },
-                {
-                    filterValue: "vegan",
-                    value: "Vegan"
-                },
-                {
-                    filterValue: "gluten-free",
-                    value: "Gluten Free"
-                }
-            ]
-        }
-
-    ]
+export const distanceOptions = [
+    {
+        filterValue: "ignore",
+        value: "Bird's-eye view"
+    },
+    {
+        filterValue: "500",
+        value: "500 meters radius",
+    },
+    {
+        filterValue: "1000",
+        value: "1km radius"
+    },
+    {
+        filterValue: "3000",
+        value: "5km radius",
+    }
+]

--- a/frontend/src/components/filtration/FiltersData.js
+++ b/frontend/src/components/filtration/FiltersData.js
@@ -1,0 +1,206 @@
+export const filters = [
+        {
+            category: "cuisine",
+            filterName: "Cuisine",
+            options: [
+                {
+                    filterValue: "american",
+                    value: "American"
+                },
+                {
+                    filterValue: "asian",
+                    value: "Asian"
+                },
+                {
+                    filterValue: "italian",
+                    value: "Italian"
+                },
+                {
+                    filterValue: "indian",
+                    value: "Indian"
+                },
+                {
+                    filterValue: "japanese",
+                    value: "Japanese"
+                },
+                {
+                    filterValue: "vietnamese",
+                    value: "Vietnamese"
+                },
+                {
+                    filterValue: "spanish",
+                    value: "Spanish"
+                },
+                {
+                    filterValue: "mediterranean",
+                    value: "Mediterranean"
+                },
+                {
+                    filterValue: "french",
+                    value: "French"
+                },
+                {
+                    filterValue: "thai",
+                    value: "Thai"
+                },
+                 {
+                    filterValue: "mexican",
+                    value: "Mexican"
+                },
+                {
+                    filterValue: "international",
+                    value: "International"
+                },
+                {
+                    filterValue: "czech",
+                    value: "Czech"
+                },
+                {
+                    filterValue: "english",
+                    value: "English"
+                },
+                {
+                    filterValue: "balkan",
+                    value: "Balkan"
+                },
+                {
+                    filterValue: "brazil",
+                    value: "Brazil"
+                },
+                {
+                    filterValue: "russian",
+                    value: "Russian"
+                },
+                {
+                    filterValue: "chinese",
+                    value: "Chinese"
+                },
+                {
+                    filterValue: "greek",
+                    value: "Greek"
+                },
+                 {
+                    filterValue: "arabic",
+                    value: "Arabic"
+                },
+                {
+                    filterValue: "korean",
+                    value: "Korean"
+                }
+
+
+
+            ]
+        },
+        {
+            category: "price-range",
+            filterName: "Price Range",
+            options: [
+                {
+                    filterValue: "0-300",
+                    value: "0 - 300 Kč"
+                },
+                {
+                    filterValue: "300-600",
+                    value: "300 - 600 Kč"
+                },
+                {
+                    filterValue: "600-",
+                    value: "Over 600 Kč"
+                }
+            ]
+        },
+        {
+            category: "other",
+            filterName: "Services",
+            options: [
+                {
+                    filterValue: "delivery-options",
+                    value: "Delivery"
+                },
+                {
+                    filterValue: "takeaway",
+                    value: "Takeaway"
+                }
+            ]
+        },
+        {
+            category: "district",
+            filterName: "Localities",
+            options: [
+                {
+                    filterValue: "Praha 1",
+                    value: "Praha 1"
+                },
+                {
+                    filterValue: "Praha 2",
+                    value: "Praha 2"
+                },
+                {
+                    filterValue: "Praha 3",
+                    value: "Praha 3"
+                },
+                                {
+                    filterValue: "Praha 4",
+                    value: "Praha 4"
+                },
+                                {
+                    filterValue: "Praha 5",
+                    value: "Praha 5"
+                },
+                {
+                    filterValue: "Praha 6",
+                    value: "Praha 6"
+                },
+                {
+                    filterValue: "Praha 7",
+                    value: "Praha 7"
+                },
+                                {
+                    filterValue: "Praha 8",
+                    value: "Praha 8"
+                },
+                                {
+                    filterValue: "Praha 9",
+                    value: "Praha 9"
+                },
+                                {
+                    filterValue: "Praha 10",
+                    value: "Praha 10"
+                }
+            ]
+        },
+        {
+             category: "other",
+            filterName: "Suggested",
+            options: [
+                {
+                    filterValue: "open now",
+                    value: "Open Now"
+                },
+                {
+                    filterValue: "near me",
+                    value: "Near me"
+                },
+            ]
+        },
+        {
+              category:"other",
+            filterName: "Featured",
+            options: [
+                {
+                    filterValue: "vegetarian",
+                    value: "Vegetarian"
+                },
+                {
+                    filterValue: "vegan",
+                    value: "Vegan"
+                },
+                {
+                    filterValue: "gluten-free",
+                    value: "Gluten Free"
+                }
+            ]
+        }
+
+    ]

--- a/frontend/src/components/filtration/VerticalFilter.css
+++ b/frontend/src/components/filtration/VerticalFilter.css
@@ -97,7 +97,7 @@
 }
 
 .option-input:hover {
- background: #a6aaaf;
+    background: #a6aaaf;
 }
 
 .option-input:checked::before {
@@ -127,7 +127,7 @@
 }
 
 .radio {
-   display: none;
+    display: none;
 }
 
 .checkmark {
@@ -142,15 +142,15 @@
 }
 
 .checkmark::after {
-     content: '';
-     width: 100%;
-     height: 100%;
-     display: block;
-     background: #00838f;
-     border-radius: 50%;
-     transform: scale(0);
-     transition: transform 0.15s;
-     animation: click-wave 0.75s;
+    content: '';
+    width: 100%;
+    height: 100%;
+    display: block;
+    background: #00838f;
+    border-radius: 50%;
+    transform: scale(0);
+    transition: transform 0.15s;
+    animation: click-wave 0.75s;
 
 }
 

--- a/frontend/src/components/filtration/VerticalFilter.js
+++ b/frontend/src/components/filtration/VerticalFilter.js
@@ -5,7 +5,7 @@ import { UserContext } from '../../UserContext';
 
 export const VerticalFilter = (props) => {
     const { clickedDistrict, setClickedDistrict,
-        clickedSuggestion, setClickedSuggestion } = useContext(UserContext)
+        clickedSuggestion, setClickedSuggestion, checkedDistance,setCheckedDistance } = useContext(UserContext)
     const [seeMoreCuisines, setSeeMoreCuisines] = useState(false);
     const [seeMoreLocalities, setSeeMoreLocalities] = useState(false);
 
@@ -25,8 +25,26 @@ export const VerticalFilter = (props) => {
         {
             category: "other",
             checkedOptions: []
-        },
+        }
     ]);
+    const distanceOptions = [
+        {
+            filterValue: "ignore",
+            value: "Bird's-eye view"
+        },
+        {
+            filterValue: "500",
+            value: "500 meters radius",
+        },
+        {
+            filterValue: "1000",
+            value: "1km radius"
+        },
+        {
+            filterValue: "3000",
+            value: "5km radius",
+        }
+    ]
 
     function handleClickCuisines () {
         setSeeMoreCuisines(!seeMoreCuisines)
@@ -59,7 +77,6 @@ export const VerticalFilter = (props) => {
         checkedFilters.map(filter => {
             if (filter.category === category) {
                 const currentIndex = filter.checkedOptions.indexOf(value)
-
             if (currentIndex === -1) {
             filter.checkedOptions.push(value);
         } else {
@@ -164,34 +181,20 @@ export const VerticalFilter = (props) => {
                     <div className="filter-inner-div">
                         <p>Distance</p>
                         <div className="filter-options">
-                            <label>
-                                <input className='radio' type='radio'
-                                    name='distance-option' />
-                                <div className="checkmark"></div>
-                                <span className="option-name">
-                                    Bird's-eye view
-                                </span>
-                            </label>
-                            <label>
-                                <input className='radio' type='radio'
-                                    name='distance-option' />
-                                <div className="checkmark"></div>
-                                <span className="option-name">
-                                    500 meters radius
-                                </span>
-                            </label>
-                            <label>
-                                <input className='radio' type='radio'
-                                    name='distance-option' />
-                                <div className="checkmark"></div>
-                                <span className="option-name">1 km radius</span>
-                            </label>
-                            <label>
-                                <input className='radio' type='radio'
-                                    name='distance-option' />
-                                <div className="checkmark"></div>
-                                <span className="option-name">3 km radius</span>
-                            </label>
+                            {distanceOptions.map(option => {
+                                return (
+                                    <label onChange={() => setCheckedDistance(option.filterValue)}>
+                                        <input className='radio' type='radio'
+                                            name='distance-option'
+                                            checked={checkedDistance === option.filterValue ? true : null}
+                                            />
+                                        <div className="checkmark"></div>
+                                        <span className="option-name">
+                                            {option.value}
+                                        </span>
+                                    </label>
+                                )
+                            })}
                         </div>
                     </div>
                 </div>

--- a/frontend/src/components/filtration/VerticalFilter.js
+++ b/frontend/src/components/filtration/VerticalFilter.js
@@ -1,42 +1,34 @@
-import React, { useState} from 'react'
+import React, { useState, useContext } from 'react'
 import './VerticalFilter.css'
+import { filters } from './FiltersData'
+import { UserContext } from '../../UserContext';
 
 export const VerticalFilter = (props) => {
+    const { clickedDistrict, setClickedDistrict,
+        clickedSuggestion, setClickedSuggestion } = useContext(UserContext)
     const [seeMoreCuisines, setSeeMoreCuisines] = useState(false);
     const [seeMoreLocalities, setSeeMoreLocalities] = useState(false);
-    const [checkedPriceRange, setCheckedPriceRange] = useState([]);
-    const [checkedFeatured, setCheckedFeatured] = useState([]);
 
-    const priceRanges = [
+    const [ checkedFilters ] = useState([
         {
-            filterValue: "0-300",
-            value: "0 - 300 Kč"
+            category: "cuisine",
+            checkedOptions: []
         },
         {
-           filterValue: "300-600",
-            value: "300 - 600 Kč"
+            category: "district",
+            checkedOptions: []
         },
         {
-           filterValue: "600-",
-           value: "Over 600 Kč"
-        }]
+            category: "price-range",
+            checkedOptions: []
+        },
+        {
+            category: "other",
+            checkedOptions: []
+        },
+    ]);
 
-    const featuredOptions = [
-        {
-            filterValue: "vegetarian",
-            value: "Vegetarian"
-        },
-        {
-            filterValue: "vegan",
-            value: "Vegan"
-        },
-        {
-            filterValue: "gluten-free",
-            value: "Gluten Free"
-        }
-    ]
-
-    function handleClick () {
+    function handleClickCuisines () {
         setSeeMoreCuisines(!seeMoreCuisines)
     }
 
@@ -44,284 +36,130 @@ export const VerticalFilter = (props) => {
         setSeeMoreLocalities(!seeMoreLocalities)
     }
 
-    const handleTogglePriceRange = (value) => {
-        const currentIndex = checkedPriceRange.indexOf(value)
-        const newChecked = [...checkedPriceRange]
-
-        if (currentIndex === -1) {
-            newChecked.push(value);
-        } else {
-            newChecked.splice(currentIndex, 1)
+    const handleCheckboxToggle = (value, category) => {
+        if (clickedDistrict !== false) {
+            checkedFilters[1].checkedOptions.push(clickedDistrict);
+            setClickedDistrict(false);
         }
 
-        setCheckedPriceRange(newChecked);
-        props.handlePriceRangeFilters(newChecked);
-    }
-
-    const handleToggleFeatured = (value) => {
-        const currentIndex = checkedFeatured.indexOf(value)
-        const newcheckedFeatured = [...checkedFeatured]
-
-        if (currentIndex === -1) {
-            newcheckedFeatured.push(value);
-        } else {
-            newcheckedFeatured.splice(currentIndex, 1)
+        if (clickedSuggestion !== false) {
+            if (clickedSuggestion === "vegetarian"
+                ||
+                clickedSuggestion === "gluten-free")
+            {
+                checkedFilters[3].checkedOptions.push(clickedSuggestion)
+                setClickedSuggestion(false);
+            }
+            else {
+                checkedFilters[0].checkedOptions.push(clickedSuggestion)
+                setClickedSuggestion(false);
+            }
         }
 
-        setCheckedFeatured(newcheckedFeatured);
-        props.handleFeaturedFilters(newcheckedFeatured);
-    }
+        checkedFilters.map(filter => {
+            if (filter.category === category) {
+                const currentIndex = filter.checkedOptions.indexOf(value)
+
+            if (currentIndex === -1) {
+            filter.checkedOptions.push(value);
+        } else {
+            filter.checkedOptions.splice(currentIndex, 1)
+        }
+          props.handlecheckedFilters(checkedFilters);
+        }
+        return null
+    })
+}
 
     return (
         <div className="vertical-filter-container">
             <div className="filter-content">
                 <p>Filters</p>
+                {filters.map(filter => (
                 <div className="filter-div">
                     <div className="filter-inner-div">
-                        <p>Cuisine</p>
+                        <p>{filter.filterName}</p>
                         <div className="filter-options">
-                            <label>
-                                <input
-                                    className='option-input checkbox'
-                                    type='checkbox'
-                                />
-                                <span className="option-name">American</span>
-                            </label>
-                            <label>
-                                <input className='option-input checkbox'
-                                    type='checkbox' />
-                                <span className="option-name">Asian</span>
-                            </label>
-                            <label>
-                                <input className='option-input checkbox'
-                                    type='checkbox' />
-                                <span className="option-name">Italian</span>
-                            </label>
-                            <div className={seeMoreCuisines ?
-                                "cuisines_shown"
+                            {filter.options.map(option => {
+                                return (
+                                filter.options.indexOf(option) >= 3 ?
+                                          <div
+                                            onChange={() =>
+                                                handleCheckboxToggle(option.filterValue,
+                                                                        filter.category)}
+                                            className={filters.indexOf(filter) >= 3 ?
+                                                (seeMoreLocalities ? "shown" : "hidden")
+                                                :
+                                                (seeMoreCuisines ? "cuisines_shown" : "cuisines_hidden")}>
+                                               <label>
+                                                 <input
+                                                    className='option-input checkbox'
+                                                    type='checkbox'
+                                                    checked={clickedDistrict === option.filterValue ?
+                                                            true
+                                                            :
+                                                            clickedSuggestion === option.filterValue ?
+                                                                true
+                                                                :
+                                                                null}
+                                                    onClick={clickedDistrict === option.filterValue ?
+                                                        () => setClickedDistrict(false)
+                                                        :
+                                                        clickedSuggestion === option.filterValue ?
+                                                            () => setClickedSuggestion(false)
+                                                            : null}
+                                                />
+                                                 <span className="option-name">{option.value}</span>
+                                                </label>
+                                        </div>
+                                        :
+                                        <label onChange={() => handleCheckboxToggle(option.filterValue,
+                                            filter.category)}
+                                        >
+                                            <input
+                                                className='option-input checkbox'
+                                                type='checkbox'
+                                                checked={clickedDistrict === option.filterValue ?
+                                                    true
+                                                    :
+                                                    clickedSuggestion === option.filterValue ?
+                                                        true
+                                                        :
+                                                        null}
+                                                onClick={clickedDistrict === option.filterValue ?
+                                                    () => setClickedDistrict(false)
+                                                    :
+                                                    clickedSuggestion === option.filterValue ?
+                                                        () => setClickedSuggestion(false)
+                                                        :
+                                                        null}
+                                            />
+                                            <span className="option-name">{option.value}</span>
+                                        </label>
+                                    )
+                                }
+                            )
+                        }
+                    </div>
+                </div>
+                    {(filter.options.length > 3) ?
+                        <p className="see-more"
+                            onClick={filters.indexOf(filter) === 3 ?
+                                handleClickLocalities
                                 :
-                                "cuisines_hidden"}>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Indian</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Japanese</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Vietnamese</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Spanish</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">
-                                        Mediterranean
-                                </span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">French</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Thai</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Mexican</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">
-                                        International
-                                </span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Czech</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">English</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Balkan</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Brazil</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Russian</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Chinese</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Greek</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Arabic</span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">Korean</span>
-                                </label>
-                            </div>
-                        </div>
-                        <p className="see-more" onClick={handleClick}>
-                            {seeMoreCuisines ? "See less" : "See more"}
-                        </p>
-                    </div>
-                </div>
-                <div className="filter-div">
-                    <div className="filter-inner-div">
-                        <p>Price Range</p>
-                        <div className="filter-options">
-                            {priceRanges.map((priceRange) => (
-                                <label onChange={() => handleTogglePriceRange(priceRange.filterValue)}>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">
-                                        {priceRange.value}
-                                    </span>
-                                </label>))}
-                        </div>
-                    </div>
-                </div>
-                <div className="filter-div">
-                    <div className="filter-inner-div">
-                        <p>Services</p>
-                        <div className="filter-options">
-                            <label>
-                                <input className='option-input checkbox'
-                                    type='checkbox' />
-                                <span className="option-name">Delivery</span>
-                            </label>
-                            <label>
-                                <input className='option-input checkbox'
-                                    type='checkbox' />
-                                <span className="option-name">Takeaway</span>
-                            </label>
-                        </div>
-                    </div>
-                </div>
-                <div className="filter-div">
-                    <div className="filter-inner-div">
-                        <p>Localities</p>
-                        <div className="filter-options">
-                            <label>
-                                <input className='option-input checkbox'
-                                    type='checkbox' />
-                                <span className="option-name">
-                                    Prague 1
-                                </span>
-                            </label>
-                            <label>
-                                <input className='option-input checkbox'
-                                    type='checkbox' />
-                                <span className="option-name">Prague 2</span>
-                            </label>
-                            <label>
-                                <input className='option-input checkbox'
-                                    type='checkbox' />
-                                <span className="option-name">Prague 3</span>
-                            </label>
-                            <div className={seeMoreLocalities ?
-                                "shown"
+                                handleClickCuisines}
+                        >
+                            {filters.indexOf(filter) === 3 ?
+                                (seeMoreLocalities ? "See less" : "See more")
                                 :
-                                "hidden"}>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">
-                                        Prague 4
-                                    </span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">
-                                        Prague 5
-                                    </span>
-                                </label>
-                                <label>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">
-                                        Prague 6
-                                    </span>
-                                </label>
-                            </div>
-                        </div>
-                        <p className="see-more" onClick={handleClickLocalities}>
-                            {seeMoreLocalities ? "See less" : "See more"}
+                                (seeMoreCuisines ? "See less" : "See more")
+                            }
                         </p>
-                    </div>
-                </div>
-                <div className="filter-div">
-                    <div className="filter-inner-div">
-                        <p>Suggested</p>
-                        <div className="filter-options">
-                            <label>
-                                <input className='option-input checkbox'
-                                    type='checkbox' />
-                                <span className="option-name">
-                                    Open Now (22:00)
-                                </span>
-                            </label>
-                            <label>
-                                <input className='option-input checkbox'
-                                    type='checkbox' />
-                                <span className="option-name">Near me</span>
-                            </label>
-                        </div>
-                    </div>
-                </div>
-                <div className="filter-div">
-                    <div className="filter-inner-div">
-                        <p>Featured</p>
-                        <div className="filter-options">
-                            {featuredOptions.map((featuredOption) => (
-                                <label onChange={() => handleToggleFeatured(featuredOption.filterValue)}>
-                                    <input className='option-input checkbox'
-                                        type='checkbox' />
-                                    <span className="option-name">
-                                        {featuredOption.value}
-                                    </span>
-                                </label>
-                            ))}
-                        </div>
-                    </div>
-                </div>
+                        :
+                        null
+                    }
+             </div>
+        ))}
                 <div className="filter-div">
                     <div className="filter-inner-div">
                         <p>Distance</p>

--- a/frontend/src/components/filtration/VerticalFilter.js
+++ b/frontend/src/components/filtration/VerticalFilter.js
@@ -1,15 +1,17 @@
 import React, { useState, useContext } from 'react'
-import './VerticalFilter.css'
-import { filters } from './FiltersData'
+import { FiltersData, distanceOptions } from './FiltersData'
 import { UserContext } from '../../UserContext';
+import './VerticalFilter.css'
 
 export const VerticalFilter = (props) => {
     const { clickedDistrict, setClickedDistrict,
-        clickedSuggestion, setClickedSuggestion, checkedDistance,setCheckedDistance } = useContext(UserContext)
+            clickedSuggestion, setClickedSuggestion,
+            checkedDistance, setCheckedDistance } = useContext(UserContext)
+
     const [seeMoreCuisines, setSeeMoreCuisines] = useState(false);
     const [seeMoreLocalities, setSeeMoreLocalities] = useState(false);
 
-    const [ checkedFilters ] = useState([
+    const [checkedFilters] = useState([
         {
             category: "cuisine",
             checkedOptions: []
@@ -27,24 +29,6 @@ export const VerticalFilter = (props) => {
             checkedOptions: []
         }
     ]);
-    const distanceOptions = [
-        {
-            filterValue: "ignore",
-            value: "Bird's-eye view"
-        },
-        {
-            filterValue: "500",
-            value: "500 meters radius",
-        },
-        {
-            filterValue: "1000",
-            value: "1km radius"
-        },
-        {
-            filterValue: "3000",
-            value: "5km radius",
-        }
-    ]
 
     function handleClickCuisines () {
         setSeeMoreCuisines(!seeMoreCuisines)
@@ -67,116 +51,118 @@ export const VerticalFilter = (props) => {
             {
                 checkedFilters[3].checkedOptions.push(clickedSuggestion)
                 setClickedSuggestion(false);
-            }
-            else {
+            } else {
                 checkedFilters[0].checkedOptions.push(clickedSuggestion)
                 setClickedSuggestion(false);
             }
         }
 
         checkedFilters.map(filter => {
+
             if (filter.category === category) {
                 const currentIndex = filter.checkedOptions.indexOf(value)
-            if (currentIndex === -1) {
-            filter.checkedOptions.push(value);
-        } else {
-            filter.checkedOptions.splice(currentIndex, 1)
-        }
-          props.handlecheckedFilters(checkedFilters);
-        }
-        return null
-    })
-}
+                if (currentIndex === -1) {
+                    filter.checkedOptions.push(value);
+                } else {
+                    filter.checkedOptions.splice(currentIndex, 1)
+                }
+                props.handlecheckedFilters(checkedFilters);
+            }
+            return null
+         })
+    }
 
     return (
         <div className="vertical-filter-container">
             <div className="filter-content">
                 <p>Filters</p>
-                {filters.map(filter => (
-                <div className="filter-div">
-                    <div className="filter-inner-div">
-                        <p>{filter.filterName}</p>
-                        <div className="filter-options">
-                            {filter.options.map(option => {
-                                return (
-                                filter.options.indexOf(option) >= 3 ?
-                                          <div
-                                            onChange={() =>
-                                                handleCheckboxToggle(option.filterValue,
-                                                                        filter.category)}
-                                            className={filters.indexOf(filter) >= 3 ?
-                                                (seeMoreLocalities ? "shown" : "hidden")
+                {FiltersData.map(filter => (
+                    <div className="filter-div">
+                        <div className="filter-inner-div">
+                            <p>{filter.filterName}</p>
+                            <div className="filter-options">
+                                {filter.options.map(option => {
+                                    return (
+                                        filter.options.indexOf(option) >= 3 ?
+                                                <div
+                                                    onChange={() =>
+                                                        handleCheckboxToggle(option.filterValue,
+                                                                                filter.category)}
+                                                    className={FiltersData.indexOf(filter) >= 3 ?
+                                                        (seeMoreLocalities ? "shown" : "hidden")
+                                                        :
+                                                        (seeMoreCuisines ? "cuisines_shown" : "cuisines_hidden")}>
+                                                    <label>
+                                                        <input
+                                                            className='option-input checkbox'
+                                                            type='checkbox'
+                                                            checked={clickedDistrict === option.filterValue ?
+                                                                    true
+                                                                    :
+                                                                    clickedSuggestion === option.filterValue ?
+                                                                        true
+                                                                        :
+                                                                        null}
+                                                            onClick={clickedDistrict === option.filterValue ?
+                                                                () => setClickedDistrict(false)
+                                                                :
+                                                                clickedSuggestion === option.filterValue ?
+                                                                    () => setClickedSuggestion(false)
+                                                                    : null}
+                                                        />
+                                                        <span className="option-name">{option.value}</span>
+                                                    </label>
+                                                </div>
                                                 :
-                                                (seeMoreCuisines ? "cuisines_shown" : "cuisines_hidden")}>
-                                               <label>
-                                                 <input
-                                                    className='option-input checkbox'
-                                                    type='checkbox'
-                                                    checked={clickedDistrict === option.filterValue ?
+                                                <label
+                                                    onChange={() => handleCheckboxToggle(option.filterValue,
+                                                                                         filter.category)}
+                                                >
+                                                    <input
+                                                        className='option-input checkbox'
+                                                        type='checkbox'
+                                                        checked={clickedDistrict === option.filterValue ?
                                                             true
                                                             :
                                                             clickedSuggestion === option.filterValue ?
                                                                 true
                                                                 :
                                                                 null}
-                                                    onClick={clickedDistrict === option.filterValue ?
-                                                        () => setClickedDistrict(false)
-                                                        :
-                                                        clickedSuggestion === option.filterValue ?
-                                                            () => setClickedSuggestion(false)
-                                                            : null}
-                                                />
-                                                 <span className="option-name">{option.value}</span>
+                                                        onClick={clickedDistrict === option.filterValue ?
+                                                            () => setClickedDistrict(false)
+                                                            :
+                                                            clickedSuggestion === option.filterValue ?
+                                                                () => setClickedSuggestion(false)
+                                                                :
+                                                                null}
+                                                    />
+                                                    <span className="option-name">{option.value}</span>
                                                 </label>
-                                        </div>
-                                        :
-                                        <label onChange={() => handleCheckboxToggle(option.filterValue,
-                                            filter.category)}
-                                        >
-                                            <input
-                                                className='option-input checkbox'
-                                                type='checkbox'
-                                                checked={clickedDistrict === option.filterValue ?
-                                                    true
-                                                    :
-                                                    clickedSuggestion === option.filterValue ?
-                                                        true
-                                                        :
-                                                        null}
-                                                onClick={clickedDistrict === option.filterValue ?
-                                                    () => setClickedDistrict(false)
-                                                    :
-                                                    clickedSuggestion === option.filterValue ?
-                                                        () => setClickedSuggestion(false)
-                                                        :
-                                                        null}
-                                            />
-                                            <span className="option-name">{option.value}</span>
-                                        </label>
+                                            )
+                                        }
                                     )
                                 }
-                            )
+                            </div>
+                        </div>
+                        {(filter.options.length > 3) ?
+                            <p
+                                className="see-more"
+                                onClick={FiltersData.indexOf(filter) === 3 ?
+                                    handleClickLocalities
+                                    :
+                                    handleClickCuisines}
+                            >
+                                {FiltersData.indexOf(filter) === 3 ?
+                                    (seeMoreLocalities ? "See less" : "See more")
+                                    :
+                                    (seeMoreCuisines ? "See less" : "See more")
+                                }
+                            </p>
+                            :
+                            null
                         }
-                    </div>
                 </div>
-                    {(filter.options.length > 3) ?
-                        <p className="see-more"
-                            onClick={filters.indexOf(filter) === 3 ?
-                                handleClickLocalities
-                                :
-                                handleClickCuisines}
-                        >
-                            {filters.indexOf(filter) === 3 ?
-                                (seeMoreLocalities ? "See less" : "See more")
-                                :
-                                (seeMoreCuisines ? "See less" : "See more")
-                            }
-                        </p>
-                        :
-                        null
-                    }
-             </div>
-        ))}
+            ))}
                 <div className="filter-div">
                     <div className="filter-inner-div">
                         <p>Distance</p>

--- a/frontend/src/components/footer/Footer.js
+++ b/frontend/src/components/footer/Footer.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import './Footer.css';
 import { Link } from 'react-router-dom';
+import './Footer.css';
 
 function Footer() {
   return (

--- a/frontend/src/components/forms/AnimatedForms.js
+++ b/frontend/src/components/forms/AnimatedForms.js
@@ -2,11 +2,10 @@ import React, { useState } from "react";
 import { useSpring, animated } from "react-spring";
 import SignUpForm from './signup/SignUpForm'
 import LoginForm from './login/LogInForm'
-import './AnimatedForms.css'
 import FormSuccess from "./signup/FormSuccess";
+import './AnimatedForms.css'
 
 export const AnimatedForms = ({signup,login}) => {
-
   const [signupFormStatus, setSignupFormStatus] = useState(signup);
   const [loginFormStatus, setLoginFormStatus] = useState(login);
   const [isSubmitted, setIsSubmitted] = useState(false);
@@ -14,6 +13,7 @@ export const AnimatedForms = ({signup,login}) => {
   const loginProps = useSpring({
     left: signupFormStatus ? -500 : 0, // Login form sliding positions
   });
+  
   const signupProps = useSpring({
     left: loginFormStatus ? 500 : 0, // Signup form sliding positions
   });

--- a/frontend/src/components/forms/login/LogInForm.js
+++ b/frontend/src/components/forms/login/LogInForm.js
@@ -28,7 +28,12 @@ const LogInForm = () => {
           <input className='checkbox-input' type='checkbox'/>
           <span>Remember me</span>
         </div>
-        <Button className='form-input-btn' buttonStyle="btn--form" buttonSize="btn--large" type='submit'>
+        <Button
+          className='form-input-btn'
+          buttonStyle="btn--form"
+          buttonSize="btn--large"
+          type='submit'
+        >
           Log in
         </Button>
       </form>

--- a/frontend/src/components/forms/signup/SignUpForm.js
+++ b/frontend/src/components/forms/signup/SignUpForm.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import validate from './validateInfo';
 import useForm from './useForm';
-import '../Form.css';
 import { Button } from '../../button/Button'
+import '../Form.css';
 
 const SignUpForm = ({ submitForm }) => {
   const { handleChange, handleSubmit, values, errors } = useForm(
@@ -60,7 +60,12 @@ const SignUpForm = ({ submitForm }) => {
           />
           {errors.password2 && <p>{errors.password2}</p>}
         </div>
-        <Button buttonStyle="btn--form" buttonSize="btn--large" type='submit'onClick={handleSubmit}>
+        <Button
+          buttonStyle="btn--form"
+          buttonSize="btn--large"
+          type='submit'
+          onClick={handleSubmit}
+        >
           Sign up
         </Button>
       </form>

--- a/frontend/src/components/navbar/MobileNavbar.js
+++ b/frontend/src/components/navbar/MobileNavbar.js
@@ -1,11 +1,33 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { UserContext } from "../../UserContext"
 
 const MobileNavbar = () => {
   const [click, setClick] = useState(false);
   const [button, setButton] = useState(true);
+  const { setPragueCollegePath } = useContext(UserContext)
+  const { setClickedDistrict, setClickedSuggestion} = useContext(UserContext)
 
   const handleClick = () => setClick(!click);
-  const closeMobileMenu = () => setClick(false);
+
+  const closeMenuOpenRestaurants = () => {
+    setClick(false);
+    setPragueCollegePath(false)
+    setClickedDistrict(false)
+    setClickedSuggestion(false)
+  }
+  const closeMenuOpenPCRestaurants = () => {
+    setClick(false);
+    setPragueCollegePath(true);
+    setClickedDistrict(false);
+    setClickedSuggestion(false);
+  }
+
+  const closeMenuDiscardChanges = () => {
+    setClick(false);
+    setPragueCollegePath(false);
+    setClickedDistrict(false);
+    setClickedSuggestion(false);
+   }
 
   const showButton = () => {
     if (window.innerWidth <= 1120) {
@@ -23,7 +45,11 @@ const MobileNavbar = () => {
     }
   };
 
-  return{click, button, showButton, handleClick, closeMobileMenu, showSearch}
+  return {
+    click, button, showButton, handleClick,
+    showSearch, closeMenuOpenRestaurants,
+    closeMenuOpenPCRestaurants, closeMenuDiscardChanges
+  }
 
 }
 

--- a/frontend/src/components/navbar/Navbar.js
+++ b/frontend/src/components/navbar/Navbar.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 import { Button } from '../button/Button';
 import MobileNavbar from './MobileNavbar'
 import { Link } from 'react-router-dom';
@@ -6,14 +6,29 @@ import './Navbar.css';
 import { Modal } from '../forms/Modal'
 import Searchbox from '../search/Searchbox';
 import NavbarLogic from './NavbarLogic';
+import { UserContext } from '../../UserContext';
 
 function Navbar() {
-  const { click, button, showButton, handleClick, closeMobileMenu }
+  const { click, button, showButton,
+          handleClick, closeMenuDiscardChanges }
     = MobileNavbar();
   const { navMenuClassName, searchbox, showLogInModal,
           showSignUpModal, openLogInModal, openSignUpModal,
           setShowLogInModal, setShowSignUpModal }
     = NavbarLogic();
+  const { pragueCollegePath, setPragueCollegePath } = useContext(UserContext)
+
+   function setRestaurantsNavLink () {
+    switch(window.location.pathname){
+      case '/restaurants':
+         return (pragueCollegePath === true ?
+           "All Restaurants"
+           :
+           "PC Restaurants")
+      default:
+        return "All Restaurants";
+    }
+  }
 
   useEffect(() => {
    showButton();
@@ -25,7 +40,7 @@ function Navbar() {
     <>
       <nav className={click ? 'navbar active' : 'navbar'}>
         <div className='navbar-container'>
-          <Link to='/' className='navbar-logo' onClick={closeMobileMenu}>
+          <Link to='/' className='navbar-logo' onClick={closeMenuDiscardChanges}>
            Restaurateur<i class="fas fa-utensils" />
           </Link>
           <div className={click ? 'hidden' : searchbox}>
@@ -36,7 +51,7 @@ function Navbar() {
           </div>
           <ul className={click ? 'nav-menu active' : navMenuClassName}>
             <li className='nav-item'>
-              <Link to='/' className='nav-links' onClick={closeMobileMenu}>
+              <Link to='/' className='nav-links' onClick={closeMenuDiscardChanges}>
                 Home
               </Link>
             </li>
@@ -44,9 +59,12 @@ function Navbar() {
               <Link
                 to='/restaurants'
                 className='nav-links'
-                onClick={closeMobileMenu}
+                onClick={setRestaurantsNavLink() === "All Restaurants" ?
+                  () => setPragueCollegePath(false)
+                  :
+                  () => setPragueCollegePath(true)}
               >
-                Restaurants
+                {setRestaurantsNavLink()}
               </Link>
             </li>
             <li>

--- a/frontend/src/components/restaurants/RestaurantItem.css
+++ b/frontend/src/components/restaurants/RestaurantItem.css
@@ -214,5 +214,5 @@
 }
 
 .error {
-    margin-top: 15rem;
+  margin-top: 15rem;
 }

--- a/frontend/src/components/restaurants/RestaurantItem.js
+++ b/frontend/src/components/restaurants/RestaurantItem.js
@@ -5,61 +5,66 @@ import { PhotoSlider } from './PhotoSlider/PhotoSlider';
 import MobileNavbar from '../navbar/MobileNavbar'
 
 function RestaurantItem(props) {
-  const {click, handleClick }
-    = MobileNavbar();
+  const {click, handleClick } = MobileNavbar();
 
   return (
     <>
       <li className='restaurant_card_item'>
-          <div className="content">
+        <div className="content">
           <PhotoSlider slides={props.photos} />
-              <div className="restaurant_description">
+          <div className="restaurant_description">
             <span className="restaurant-name">
               <div className="name-container">{props.name}</div>
-                  <div className="save-container">
-                    <i onClick={handleClick}
-                      className={click ? "save-btn-active"
-                                  : "save-btn"}>
-                    </i>
+              <div className="save-container">
+                <i onClick={handleClick}
+                  className={click ? "save-btn-active"
+                              : "save-btn"}>
+                </i>
                 <div className={click ? 'save-on-hover-hidden'
-                                 : 'save-on-hover'}>
-                      Click to Save
-                    </div>
-                  <div className={click ? "saved" : "saved-hidden"}>Saved</div></div>
-                </span>
-                  <div className="rating-container">
-                  <Rating name="read-only" value={props.rating}
-                          precision={0.1} readOnly
-                  />
-                  <span className="rating-num">({props.rating})</span>
+                               : 'save-on-hover'}>
+                    Click to Save
+                </div>
+                <div className={click ? "saved" : "saved-hidden"}>Saved</div>
+              </div>
+            </span>
+          <div className="rating-container">
+              <Rating name="read-only"
+                      value={props.rating}
+                      precision={0.1}
+                      readOnly
+              />
+              <span className="rating-num">({props.rating})</span>
+          </div>
+            <span className="tags">{props.tags}</span>
+            <span className="address">{props.address}, {props.district}</span>
+            <span className="price-range">Price Range: {props.price}</span>
+            <span className="takeaway">
+              <i className={props.takeaway === true ?
+                  "fas fa-check" : "fas fa-times"}>
+              </i>
+              Takeaway
+            </span>
+            <span className="delivery">
+                <i className={props.delivery != null ?
+                  "fas fa-check" : "fas fa-times"}></i>Delivery</span>
+                <div className="more-options">
+                  <div className="option">
+                    Call
+                    <i className="fas fa-phone"></i>
                   </div>
-                  <span className="tags">{props.tags}</span>
-                  <span className="address">{props.address}, {props.district}</span>
-                  <span className="price-range">Price Range: {props.price}</span>
-                  <span className="takeaway">
-                  <i className={props.takeaway === true ?
-                    "fas fa-check" : "fas fa-times"}></i>Takeaway</span>
-                  <span className="delivery">
-                    <i className={props.delivery != null ?
-                      "fas fa-check" : "fas fa-times"}></i>Delivery</span>
-                  <div className="more-options">
-                    <div className="option">
-                      Call
-                      <i className="fas fa-phone"></i>
-                    </div>
-                    <div className="option">
-                      Menu
-                      <i className="fab fa-elementor"></i>
-                    </div>
-                    <div className="option view">
-                      View More
-                      <i className="fas fa-angle-right" />
-                    </div>
+                  <div className="option">
+                    Menu
+                    <i className="fab fa-elementor"></i>
+                  </div>
+                  <div className="option view">
+                    View More
+                    <i className="fas fa-angle-right" />
                   </div>
                 </div>
-          </div>
-      </li>
-    </>
+              </div>
+        </div>
+    </li>
+  </>
   );
 }
 

--- a/frontend/src/components/restaurants/pagination/Pagination.js
+++ b/frontend/src/components/restaurants/pagination/Pagination.js
@@ -12,8 +12,8 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function RestaurantPagination({ restaurantsPerPage, totalRestaurants, paginate }) {
-
   const pageNumbers = [];
+  
   for (let i = 1; i <= Math.ceil(totalRestaurants / restaurantsPerPage); i++) {
     pageNumbers.push(i);
   }

--- a/frontend/src/pages/Restaurants.js
+++ b/frontend/src/pages/Restaurants.js
@@ -18,6 +18,8 @@ export default function Restaurants() {
   const pragueCollegePath = useContext(UserContext)
   const clickedDistrict = useContext(UserContext)
   const clickedSuggestion = useContext(UserContext)
+  const checkedDistance = useContext(UserContext)
+  console.log(checkedDistance.checkedDistance)
 
   const [checkedFilters, setCheckedFilters] = useState([]);
   const [restaurants, setRestaurants] = useState([]);
@@ -49,7 +51,7 @@ export default function Restaurants() {
 
   const showFilteredResults = () => {
     if (pragueCollegePath.pragueCollegePath === true) {
-      var pragueCollegeRestaurants = "/prague-college/restaurants?"
+       var pragueCollegeRestaurants = `/prague-college/restaurants?radius=${checkedDistance.checkedDistance}`
       if (clickedDistrict.clickedDistrict !== false) {
         pragueCollegeRestaurants += `district=${clickedDistrict.clickedDistrict}`
       }
@@ -84,6 +86,7 @@ export default function Restaurants() {
     }
   }
   const path = showFilteredResults();
+  console.log()
 
   useEffect(() => {
     fetch(`${path}`).then(response => response.json()).then(

--- a/frontend/src/pages/Restaurants.js
+++ b/frontend/src/pages/Restaurants.js
@@ -19,7 +19,6 @@ export default function Restaurants() {
   const clickedDistrict = useContext(UserContext)
   const clickedSuggestion = useContext(UserContext)
   const checkedDistance = useContext(UserContext)
-  console.log(checkedDistance.checkedDistance)
 
   const [checkedFilters, setCheckedFilters] = useState([]);
   const [restaurants, setRestaurants] = useState([]);
@@ -51,42 +50,43 @@ export default function Restaurants() {
 
   const showFilteredResults = () => {
     if (pragueCollegePath.pragueCollegePath === true) {
-       var pragueCollegeRestaurants = `/prague-college/restaurants?radius=${checkedDistance.checkedDistance}&`
+      var pragueCollegeRestaurants =
+        `/prague-college/restaurants?radius=${checkedDistance.checkedDistance}&`
+
       if (clickedDistrict.clickedDistrict !== false) {
         pragueCollegeRestaurants += `district=${clickedDistrict.clickedDistrict}`
       }
+
       if (clickedSuggestion.clickedSuggestion !== false) {
-        if (clickedSuggestion.clickedSuggestion === "vegetarian"
-          ||
+        if (clickedSuggestion.clickedSuggestion === "vegetarian" ||
           clickedSuggestion.clickedSuggestion === "gluten-free") {
           pragueCollegeRestaurants += `${clickedSuggestion.clickedSuggestion}`
-        }
-        else {
-          pragueCollegeRestaurants += `cuisine=${clickedSuggestion.clickedSuggestion}`
+        } else {
+          pragueCollegeRestaurants +=
+            `cuisine=${clickedSuggestion.clickedSuggestion}`
         }
       }
       return pragueCollegeRestaurants + arrayOfPathValues.join("&")
-    }
-    else {
-      var path = "/restaurants?radius=ignore&"
-      if (clickedDistrict.clickedDistrict !== false) {
-        path += `district=${clickedDistrict.clickedDistrict}`
+    } else {
+        var path = "/restaurants?radius=ignore&"
+        if (clickedDistrict.clickedDistrict !== false) {
+          path += `district=${clickedDistrict.clickedDistrict}`
       }
       if (clickedSuggestion.clickedSuggestion !== false) {
         if (clickedSuggestion.clickedSuggestion === "vegetarian"
           ||
           clickedSuggestion.clickedSuggestion === "gluten-free") {
             path += clickedSuggestion.clickedSuggestion
-          }
-        else {
-           path += `cuisine=${clickedSuggestion.clickedSuggestion}`
+          } else {
+              path += `cuisine=${clickedSuggestion.clickedSuggestion}`
         }
       }
       return path + arrayOfPathValues.join("&")
     }
   }
+
   const path = showFilteredResults();
-  console.log()
+
 
   useEffect(() => {
     fetch(`${path}`).then(response => response.json()).then(
@@ -97,11 +97,9 @@ export default function Restaurants() {
   if (restaurants !== null) {
     var currentRestaurants = restaurants.slice(
       indexOfFirstRestaurant, indexOfLastRestaurant);
+  } else {
+      currentRestaurants = null
   }
-  else {
-    currentRestaurants = null
-  }
-  console.log(showFilteredResults())
 
   return (
     <>
@@ -132,7 +130,7 @@ export default function Restaurants() {
               isSearchable
             />
           </div>
-          {restaurants ?
+          {restaurants.length !== 0 ?
             currentRestaurants.map(filteredRestaurant => {
               return <RestaurantItem
                 photos={filteredRestaurant.Images.length !== 0 ?
@@ -143,10 +141,14 @@ export default function Restaurants() {
                 tags={filteredRestaurant.Cuisines !== null ?
                   filteredRestaurant.Cuisines.map((cuisine) => {
                     if (filteredRestaurant.Cuisines.indexOf(cuisine) ===
-                      filteredRestaurant.Cuisines.length - 1)
-                  { return cuisine }
-                  else { return cuisine + ","}
-                  }) : "Cuisines are not available"}
+                      filteredRestaurant.Cuisines.length - 1) {
+                      return cuisine
+                    } else {
+                        return cuisine + ","
+                      }
+                    })
+                    :
+                    "Cuisines are not available"}
                 address={filteredRestaurant.Address}
                 district={filteredRestaurant.District}
                 price={filteredRestaurant.PriceRange}
@@ -154,9 +156,10 @@ export default function Restaurants() {
                 delivery={filteredRestaurant.DeliveryOptions}
               />
             })
-            : <h1 className="error">
-                There are no results for these filters
-              </h1>
+            :
+            <h1 className="error">
+              There are no results for these filters
+            </h1>
           }
         </div>
       </div>

--- a/frontend/src/pages/Restaurants.js
+++ b/frontend/src/pages/Restaurants.js
@@ -149,7 +149,7 @@ export default function Restaurants() {
                   }) : "Cuisines are not available"}
                 address={filteredRestaurant.Address}
                 district={filteredRestaurant.District}
-                price={filteredRestaurant.checkedFilters}
+                price={filteredRestaurant.PriceRange}
                 takeaway={filteredRestaurant.Takeaway}
                 delivery={filteredRestaurant.DeliveryOptions}
               />

--- a/frontend/src/pages/Restaurants.js
+++ b/frontend/src/pages/Restaurants.js
@@ -51,7 +51,7 @@ export default function Restaurants() {
 
   const showFilteredResults = () => {
     if (pragueCollegePath.pragueCollegePath === true) {
-       var pragueCollegeRestaurants = `/prague-college/restaurants?radius=${checkedDistance.checkedDistance}`
+       var pragueCollegeRestaurants = `/prague-college/restaurants?radius=${checkedDistance.checkedDistance}&`
       if (clickedDistrict.clickedDistrict !== false) {
         pragueCollegeRestaurants += `district=${clickedDistrict.clickedDistrict}`
       }

--- a/frontend/src/test/__snapshots__/Cards.test.js.snap
+++ b/frontend/src/test/__snapshots__/Cards.test.js.snap
@@ -18,6 +18,7 @@ exports[`testing Cards should render 1`] = `
       >
         <li
           className="cards__item"
+          onClick={[Function]}
         >
           <a
             className="cards__item__link"
@@ -47,6 +48,7 @@ exports[`testing Cards should render 1`] = `
         </li>
         <li
           className="cards__item"
+          onClick={[Function]}
         >
           <a
             className="cards__item__link"
@@ -80,6 +82,7 @@ exports[`testing Cards should render 1`] = `
       >
         <li
           className="cards__item"
+          onClick={[Function]}
         >
           <a
             className="cards__item__link"
@@ -109,6 +112,7 @@ exports[`testing Cards should render 1`] = `
         </li>
         <li
           className="cards__item"
+          onClick={[Function]}
         >
           <a
             className="cards__item__link"
@@ -138,6 +142,7 @@ exports[`testing Cards should render 1`] = `
         </li>
         <li
           className="cards__item"
+          onClick={[Function]}
         >
           <a
             className="cards__item__link"
@@ -146,7 +151,7 @@ exports[`testing Cards should render 1`] = `
           >
             <figure
               className="cards__item__pic-wrap"
-              data-category="Vegan/Vegetarian"
+              data-category="Vegetarian"
             >
               <img
                 alt="Food Category"
@@ -160,7 +165,7 @@ exports[`testing Cards should render 1`] = `
               <h5
                 className="cards__item__text"
               >
-                Check out the restaurants with vegan and vegetarian meals
+                Check out the restaurants with vegetarian meals
               </h5>
             </div>
           </a>

--- a/frontend/src/test/__snapshots__/Districts.test.js.snap
+++ b/frontend/src/test/__snapshots__/Districts.test.js.snap
@@ -21,6 +21,7 @@ exports[`testing CollegeSection should render 1`] = `
       >
         <li
           className="districts__item"
+          onClick={[Function]}
         >
           <a
             className="districts__item__link"
@@ -28,9 +29,9 @@ exports[`testing CollegeSection should render 1`] = `
             onClick={[Function]}
           >
             <h4>
-              Prague 1
+              Praha 1
                (
-              50
+              1062
                places)
             </h4>
             <i
@@ -40,6 +41,7 @@ exports[`testing CollegeSection should render 1`] = `
         </li>
         <li
           className="districts__item"
+          onClick={[Function]}
         >
           <a
             className="districts__item__link"
@@ -47,9 +49,9 @@ exports[`testing CollegeSection should render 1`] = `
             onClick={[Function]}
           >
             <h4>
-              Prague 2
+              Praha 2
                (
-              50
+              387
                places)
             </h4>
             <i
@@ -59,6 +61,7 @@ exports[`testing CollegeSection should render 1`] = `
         </li>
         <li
           className="districts__item"
+          onClick={[Function]}
         >
           <a
             className="districts__item__link"
@@ -66,9 +69,9 @@ exports[`testing CollegeSection should render 1`] = `
             onClick={[Function]}
           >
             <h4>
-              Prague 3
+              Praha 4
                (
-              50
+              296
                places)
             </h4>
             <i
@@ -82,6 +85,7 @@ exports[`testing CollegeSection should render 1`] = `
       >
         <li
           className="districts__item"
+          onClick={[Function]}
         >
           <a
             className="districts__item__link"
@@ -89,9 +93,9 @@ exports[`testing CollegeSection should render 1`] = `
             onClick={[Function]}
           >
             <h4>
-              Prague 4
+              Praha 5
                (
-              50
+              310
                places)
             </h4>
             <i
@@ -101,6 +105,7 @@ exports[`testing CollegeSection should render 1`] = `
         </li>
         <li
           className="districts__item"
+          onClick={[Function]}
         >
           <a
             className="districts__item__link"
@@ -108,9 +113,9 @@ exports[`testing CollegeSection should render 1`] = `
             onClick={[Function]}
           >
             <h4>
-              Prague 5
+              Praha 6
                (
-              50
+              222
                places)
             </h4>
             <i
@@ -120,6 +125,7 @@ exports[`testing CollegeSection should render 1`] = `
         </li>
         <li
           className="districts__item"
+          onClick={[Function]}
         >
           <a
             className="districts__item__link"
@@ -127,9 +133,9 @@ exports[`testing CollegeSection should render 1`] = `
             onClick={[Function]}
           >
             <h4>
-              Prague 6
+              Praha 10
                (
-              50
+              259
                places)
             </h4>
             <i


### PR DESCRIPTION
- Added logic for the remaining filters: 
  - cuisines
  - services
  - localities
  - featured
  - distance (only for Prague College Restaurants with the default value of 1000 meters)

Open now and Suggested options are not working as they're not yet fully implemented in the backend. The distance options for all the restaurants need a specific address which I suppose will be the user's input of the specific location.
-  Implemented the dynamic link in Navbar. The link suggests PC restaurants if all the restaurants of Prague are displayed and vice versa.
- The sections top suggestions and popular districts redirect the user to the restaurants page, filter the restaurants and automatically check the corresponding checkbox. All the filter/filters, except the chosen distance, are discarded when the user goes back to the homepage. The checked filters are remembered even if the user switches to the PC restaurants page(same goes with the Restaurants page). The user can uncheck the chosen option.