### PR TITLE
26 implement search

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -45,14 +45,32 @@ For now the server listens on port 8080, later the port should be configurable.
 
 ## Currently implemented
 
-HTTP server with two endpoints
+HTTP server with three endpoints
 
-| Method | Path                        | Handler       |
-|--------|-----------------------------|---------------|
+| Method | Path                        | Handler              |
+|--------|-----------------------------|----------------------|
 | GET    | /prague-college/restaurants | pcRestaurantsHandler |
-| GET | /restaurants | restaurantsHandler
+| GET    | /restaurants                | restaurantsHandler   |
+| GET    | /autocomplete               | autocompleteHandler  |
 
-## Query parameters
+
+## Query parameters for `/prague-college/restaurants` and `/restaurants`
+
+### search-name
+
+Name for which the database will be queried, results will be returned and ordered based on a similarity rating.
+
+**Example**
+
+`restaurants?radius=ignore&search-name=steak`
+
+### search-address
+
+Address for which the database will be queried, results will be returned and ordered based on a similarity rating.
+
+**Example**
+
+`prague-college/restaurants?search-address=manesova`
 
 ### radius
 
@@ -172,8 +190,6 @@ Filters out restaurants without a delivery option.
 
 `delivery-options`
 
----
-
 ## Example JSON responses
 ```json
 {
@@ -253,3 +269,41 @@ Filters out restaurants without a delivery option.
   "Data": null
 }
 ```
+---
+
+## Query parameters for `/autocomplete`
+
+### name
+
+Provides up to 10 candidates for autocompletion.
+
+**Example**
+
+`/autocomplete?name=steak`
+
+`/autocomplete?address=manesova`
+
+
+## Example JSON response
+
+```json
+{
+  "Status": 200,
+  "Msg": "Success",
+  "Data": [
+    {
+      "ID": 708,
+      "Name": "Empír steak",
+      "Address": "Beranových 39",
+      "District": "Praha 9"
+    },
+    {
+      "ID": 1061,
+      "Name": "SteakBurger",
+      "Address": "Krhanická 994/21a",
+      "District": "Praha 4"
+    }
+  ]
+}
+```
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -47,11 +47,12 @@ For now the server listens on port 8080, later the port should be configurable.
 
 HTTP server with three endpoints
 
-| Method | Path                        | Handler              |
-|--------|-----------------------------|----------------------|
-| GET    | /prague-college/restaurants | pcRestaurantsHandler |
-| GET    | /restaurants                | restaurantsHandler   |
-| GET    | /autocomplete               | autocompleteHandler  |
+| Method | Path                         | Handler              |
+|--------|------------------------------|----------------------|
+| GET    | /prague-college/restaurants  | pcRestaurantsHandler |
+| GET    | /restaurants                 | restaurantsHandler   |
+| GET    | /autocomplete                | autocompleteHandler  |
+| GET    | /restaurant/{restaurant-id}  | restaurantHandler    |
 
 
 ## Query parameters for `/prague-college/restaurants` and `/restaurants`

--- a/backend/db.go
+++ b/backend/db.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lib/pq"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -58,7 +59,15 @@ type RestaurantDB struct {
 	DeliveryOptions pq.StringArray `db:"delivery_options"`
 }
 
-func (restaurant *RestaurantDB) isInRadius(lat, lon, radius float64) bool {
+func (restaurant *RestaurantDB) isInRadius(lat, lon float64, radiusParam string) bool {
+	if radiusParam == "ignore" {
+		return true
+	}
+	radius, errRad := strconv.ParseFloat(radiusParam, 64)
+	if errRad != nil {
+		// default value
+		radius = 1000
+	}
 	distance := haversine(lat, lon, restaurant.Lat, restaurant.Lon)
 	return distance <= radius
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -72,7 +72,6 @@ func getAutocompleteCandidates(params url.Values) ([]*restaurantAutocomplete, er
 			"ORDER BY SIMILARITY(unaccent(address), unaccent($1)) DESC"
 		input = params.Get("address")
 	}
-	log.Println(pgQuery)
 	var restaurants []*restaurantAutocomplete
 	conn, err := dbInitialise()
 	if err != nil {

--- a/backend/main.go
+++ b/backend/main.go
@@ -313,6 +313,7 @@ func getCoordinates(params url.Values) (float64, float64, error) {
 }
 
 func restaurantHandler(w http.ResponseWriter, r *http.Request) {
+	logRequest(r, "restaurantHandler")
 	res := responseJSON{}
 	id, err := strconv.Atoi(mux.Vars(r)["id"])
 	if err != nil {


### PR DESCRIPTION
Added `/restaurant/{id}` endpoint which returns a JSON for 1 restaurant based on provided ID.

The completion uses 2 built-in postgres extensions which you have to enable like so:

```sql
CREATE EXTENSION pg_trgm;
```
```sql
CREATE EXTENSION unaccent;
```
---

Implemented 2 new queries for `/restaurants` and `/prague-college/restaurants`


search-address=\<address\> Will take the provided address text and query the database for similar results.

search-name=\<name\> Will take the provided name text and query the database for similar results. 

The resulting JSON for both queries is ordered by similarity to provided text in a descending order.

---

Also added a new endpoint `/autocomplete` which can be queried for auto-completion suggestions in the search box. 
It supports completions for a restaurant's name and a restaurant's address.


Sample queries:

`/autocomplete?name=steak`

`/autocomplete?address=manesova`

The resulting JSON for both autocomplete queries is ordered by similarity to provided text in a descending order and has a max length of 10 completion candidates. The JSON looks like this:

```json
{
  "Status": 200,
  "Msg": "Success",
  "Data": [
    {
      "ID": 708,
      "Name": "Empír steak",
      "Address": "Beranových 39",
      "District": "Praha 9"
    },
    {
      "ID": 1061,
      "Name": "SteakBurger",
      "Address": "Krhanická 994/21a",
      "District": "Praha 4"
    }
  ]
}
```
The ID field can be used in case the user selects one of the suggestions to make a request to the backend for more info about only that specific restaurant.

I tested it a bit and the results seem pretty relevant, but it will be much easier to test it once it's integrated into the frontend.