### PR TITLE
Add TUI submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tui"]
+	path = tui
+	url = https://github.com/adzai/restaurateur-tui/

--- a/README.md
+++ b/README.md
@@ -108,3 +108,11 @@ https://github.com/AgiliaErnis/restaurateur/tree/main/frontend#readme
 #### Backend
 
 https://github.com/AgiliaErnis/restaurateur/tree/main/backend#readme
+
+#### TUI
+
+https://github.com/adzai/restaurateur-tui/tree/main/#readme
+
+If you don't see TUI locally, run `git submodule update --init --recursive`
+
+Alternatively just clone https://github.com/adzai/restaurateur-tui/


### PR DESCRIPTION
A TUI for the backend API. You can check the details in the README.

To clone: `git submodule update --init --recursive`

Right now it only works with test API like this `python restaurateur-tui.py --host "https://testapi.restaurateur.tech"`
because the main one is based off the old release.
Hope it will work to have it as a git submodule...
